### PR TITLE
feat: add oauthClients slice (External connectors)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uspacy/store",
-  "version": "0.0.321",
+  "version": "0.0.328",
   "keywords": [],
   "repository": "git@github.com:Uspacy/uspacy-store.git",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@typescript-eslint/eslint-plugin": "6.3.0",
     "@typescript-eslint/parser": "6.3.0",
     "@uspacy/forms": "1.0.8",
-    "@uspacy/sdk": "0.0.239",
+    "@uspacy/sdk": "0.0.240",
     "cross-env": "7.0.3",
     "date-fns": "2.30.0",
     "dotenv-webpack": "8.0.1",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -39,6 +39,7 @@ import messengerReducer from './messenger';
 import migrationsReducer from './migrations';
 import newsfeed from './newsfeed';
 import notifications from './notifications';
+import oauthClients from './oauthClients';
 import pageTitle from './pageTitle';
 import payments from './payments';
 import profile from './profile';
@@ -74,6 +75,7 @@ const rootReducer = combineReducers({
 	tasksTimer,
 	users,
 	webhooks,
+	oauthClients,
 	newsfeed,
 	migrationsReducer,
 	messengerReducer,

--- a/src/store/oauthClients/actions.ts
+++ b/src/store/oauthClients/actions.ts
@@ -25,6 +25,18 @@ export const createOAuthClient = createAsyncThunk('oauthClients/createOAuthClien
 	}
 });
 
+export const updateOAuthClient = createAsyncThunk(
+	'oauthClients/updateOAuthClient',
+	async ({ id, data }: { id: string; data: Partial<IOAuthClientRequest> }, thunkAPI) => {
+		try {
+			const res = await sdk.oauthClientsService.updateOAuthClient(id, data);
+			return res.data.data;
+		} catch (e) {
+			return thunkAPI.rejectWithValue('Failure');
+		}
+	},
+);
+
 export const deleteOAuthClient = createAsyncThunk('oauthClients/deleteOAuthClient', async (id: string, thunkAPI) => {
 	try {
 		await sdk.oauthClientsService.deleteOAuthClient(id);

--- a/src/store/oauthClients/actions.ts
+++ b/src/store/oauthClients/actions.ts
@@ -1,0 +1,44 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { uspacySdk } from '@uspacy/sdk';
+
+import { IOAuthClientRequest } from './types';
+
+// TODO: remove cast once @uspacy/sdk is published with oauthClientsService
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const sdk = uspacySdk as any;
+
+export const fetchOAuthClients = createAsyncThunk('oauthClients/fetchOAuthClients', async (_, thunkAPI) => {
+	try {
+		const res = await sdk.oauthClientsService.getOAuthClients();
+		return res.data.data.data;
+	} catch (e) {
+		return thunkAPI.rejectWithValue('Failure');
+	}
+});
+
+export const createOAuthClient = createAsyncThunk('oauthClients/createOAuthClient', async (data: IOAuthClientRequest, thunkAPI) => {
+	try {
+		const res = await sdk.oauthClientsService.createOAuthClient(data);
+		return res.data.data;
+	} catch (e) {
+		return thunkAPI.rejectWithValue('Failure');
+	}
+});
+
+export const deleteOAuthClient = createAsyncThunk('oauthClients/deleteOAuthClient', async (id: string, thunkAPI) => {
+	try {
+		await sdk.oauthClientsService.deleteOAuthClient(id);
+		return id;
+	} catch (e) {
+		return thunkAPI.rejectWithValue('Failure');
+	}
+});
+
+export const fetchAvailablePermissions = createAsyncThunk('oauthClients/fetchAvailablePermissions', async (_, thunkAPI) => {
+	try {
+		const res = await sdk.oauthClientsService.getAvailablePermissions();
+		return res.data.data;
+	} catch (e) {
+		return thunkAPI.rejectWithValue('Failure');
+	}
+});

--- a/src/store/oauthClients/actions.ts
+++ b/src/store/oauthClients/actions.ts
@@ -1,5 +1,6 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { uspacySdk } from '@uspacy/sdk';
+import { IErrorsAxiosResponse } from '@uspacy/sdk/lib/models/errors';
 
 import { IOAuthClientRequest } from './types';
 
@@ -12,7 +13,7 @@ export const fetchOAuthClients = createAsyncThunk('oauthClients/fetchOAuthClient
 		const res = await sdk.oauthClientsService.getOAuthClients();
 		return res.data.data.data;
 	} catch (e) {
-		return thunkAPI.rejectWithValue('Failure');
+		return thunkAPI.rejectWithValue(e as IErrorsAxiosResponse);
 	}
 });
 
@@ -21,7 +22,7 @@ export const createOAuthClient = createAsyncThunk('oauthClients/createOAuthClien
 		const res = await sdk.oauthClientsService.createOAuthClient(data);
 		return res.data.data;
 	} catch (e) {
-		return thunkAPI.rejectWithValue('Failure');
+		return thunkAPI.rejectWithValue(e as IErrorsAxiosResponse);
 	}
 });
 
@@ -32,7 +33,7 @@ export const updateOAuthClient = createAsyncThunk(
 			const res = await sdk.oauthClientsService.updateOAuthClient(id, data);
 			return res.data.data;
 		} catch (e) {
-			return thunkAPI.rejectWithValue('Failure');
+			return thunkAPI.rejectWithValue(e as IErrorsAxiosResponse);
 		}
 	},
 );
@@ -42,7 +43,7 @@ export const deleteOAuthClient = createAsyncThunk('oauthClients/deleteOAuthClien
 		await sdk.oauthClientsService.deleteOAuthClient(id);
 		return id;
 	} catch (e) {
-		return thunkAPI.rejectWithValue('Failure');
+		return thunkAPI.rejectWithValue(e as IErrorsAxiosResponse);
 	}
 });
 
@@ -51,6 +52,6 @@ export const fetchAvailablePermissions = createAsyncThunk('oauthClients/fetchAva
 		const res = await sdk.oauthClientsService.getAvailablePermissions();
 		return res.data.data;
 	} catch (e) {
-		return thunkAPI.rejectWithValue('Failure');
+		return thunkAPI.rejectWithValue(e as IErrorsAxiosResponse);
 	}
 });

--- a/src/store/oauthClients/index.ts
+++ b/src/store/oauthClients/index.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { IErrorsAxiosResponse } from '@uspacy/sdk/lib/models/errors';
 
-import { createOAuthClient, deleteOAuthClient, fetchAvailablePermissions, fetchOAuthClients } from './actions';
+import { createOAuthClient, deleteOAuthClient, fetchAvailablePermissions, fetchOAuthClients, updateOAuthClient } from './actions';
 import { IOAuthClient, IOAuthClientWithSecret, IOAuthPermissionGroup, IState } from './types';
 
 const initialState = {
@@ -11,6 +11,7 @@ const initialState = {
 	loadingClients: false,
 	loadingPermissions: false,
 	creating: false,
+	updating: false,
 	errorLoadingClients: null,
 } as IState;
 
@@ -50,6 +51,19 @@ const oauthClientsReducer = createSlice({
 		},
 		[createOAuthClient.rejected.type]: (state, action: PayloadAction<IErrorsAxiosResponse>) => {
 			state.creating = false;
+			state.errorLoadingClients = action.payload;
+		},
+		[updateOAuthClient.fulfilled.type]: (state, action: PayloadAction<IOAuthClient>) => {
+			state.updating = false;
+			state.errorLoadingClients = null;
+			state.clients = state.clients.map((c) => (c.client_id === action.payload.client_id ? { ...c, ...action.payload } : c));
+		},
+		[updateOAuthClient.pending.type]: (state) => {
+			state.updating = true;
+			state.errorLoadingClients = null;
+		},
+		[updateOAuthClient.rejected.type]: (state, action: PayloadAction<IErrorsAxiosResponse>) => {
+			state.updating = false;
 			state.errorLoadingClients = action.payload;
 		},
 		[deleteOAuthClient.fulfilled.type]: (state, action: PayloadAction<string>) => {

--- a/src/store/oauthClients/index.ts
+++ b/src/store/oauthClients/index.ts
@@ -55,7 +55,7 @@ const oauthClientsReducer = createSlice({
 		[deleteOAuthClient.fulfilled.type]: (state, action: PayloadAction<string>) => {
 			state.loadingClients = false;
 			state.errorLoadingClients = null;
-			state.clients = state.clients.filter((c) => c.clientId !== action.payload);
+			state.clients = state.clients.filter((c) => c.client_id !== action.payload);
 		},
 		[deleteOAuthClient.pending.type]: (state) => {
 			state.loadingClients = true;

--- a/src/store/oauthClients/index.ts
+++ b/src/store/oauthClients/index.ts
@@ -1,0 +1,82 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { IErrorsAxiosResponse } from '@uspacy/sdk/lib/models/errors';
+
+import { createOAuthClient, deleteOAuthClient, fetchAvailablePermissions, fetchOAuthClients } from './actions';
+import { IOAuthClient, IOAuthClientWithSecret, IOAuthPermissionGroup, IState } from './types';
+
+const initialState = {
+	clients: [],
+	createdClient: null,
+	availablePermissions: [],
+	loadingClients: false,
+	loadingPermissions: false,
+	creating: false,
+	errorLoadingClients: null,
+} as IState;
+
+const oauthClientsReducer = createSlice({
+	name: 'oauthClientsReducer',
+	initialState,
+	reducers: {
+		clearCreatedClient: (state) => {
+			state.createdClient = null;
+		},
+	},
+	extraReducers: {
+		[fetchOAuthClients.fulfilled.type]: (state, action: PayloadAction<IOAuthClient[]>) => {
+			state.loadingClients = false;
+			state.errorLoadingClients = null;
+			state.clients = action.payload;
+		},
+		[fetchOAuthClients.pending.type]: (state) => {
+			state.loadingClients = true;
+			state.errorLoadingClients = null;
+		},
+		[fetchOAuthClients.rejected.type]: (state, action: PayloadAction<IErrorsAxiosResponse>) => {
+			state.loadingClients = false;
+			state.errorLoadingClients = action.payload;
+		},
+		[createOAuthClient.fulfilled.type]: (state, action: PayloadAction<IOAuthClientWithSecret>) => {
+			state.creating = false;
+			state.errorLoadingClients = null;
+			state.createdClient = action.payload;
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			const { secret, ...client } = action.payload;
+			state.clients.unshift(client);
+		},
+		[createOAuthClient.pending.type]: (state) => {
+			state.creating = true;
+			state.errorLoadingClients = null;
+		},
+		[createOAuthClient.rejected.type]: (state, action: PayloadAction<IErrorsAxiosResponse>) => {
+			state.creating = false;
+			state.errorLoadingClients = action.payload;
+		},
+		[deleteOAuthClient.fulfilled.type]: (state, action: PayloadAction<string>) => {
+			state.loadingClients = false;
+			state.errorLoadingClients = null;
+			state.clients = state.clients.filter((c) => c.clientId !== action.payload);
+		},
+		[deleteOAuthClient.pending.type]: (state) => {
+			state.loadingClients = true;
+		},
+		[deleteOAuthClient.rejected.type]: (state, action: PayloadAction<IErrorsAxiosResponse>) => {
+			state.loadingClients = false;
+			state.errorLoadingClients = action.payload;
+		},
+		[fetchAvailablePermissions.fulfilled.type]: (state, action: PayloadAction<IOAuthPermissionGroup[]>) => {
+			state.loadingPermissions = false;
+			state.availablePermissions = action.payload;
+		},
+		[fetchAvailablePermissions.pending.type]: (state) => {
+			state.loadingPermissions = true;
+		},
+		[fetchAvailablePermissions.rejected.type]: (state, action: PayloadAction<IErrorsAxiosResponse>) => {
+			state.loadingPermissions = false;
+			state.errorLoadingClients = action.payload;
+		},
+	},
+});
+
+export const { clearCreatedClient } = oauthClientsReducer.actions;
+export default oauthClientsReducer.reducer;

--- a/src/store/oauthClients/index.ts
+++ b/src/store/oauthClients/index.ts
@@ -4,7 +4,7 @@ import { IErrorsAxiosResponse } from '@uspacy/sdk/lib/models/errors';
 import { createOAuthClient, deleteOAuthClient, fetchAvailablePermissions, fetchOAuthClients, updateOAuthClient } from './actions';
 import { IOAuthClient, IOAuthClientWithSecret, IOAuthPermissionGroup, IState } from './types';
 
-const initialState = {
+const initialState: IState = {
 	clients: [],
 	createdClient: null,
 	availablePermissions: [],
@@ -13,7 +13,7 @@ const initialState = {
 	creating: false,
 	updating: false,
 	errorLoadingClients: null,
-} as IState;
+};
 
 const oauthClientsReducer = createSlice({
 	name: 'oauthClientsReducer',
@@ -73,6 +73,7 @@ const oauthClientsReducer = createSlice({
 		},
 		[deleteOAuthClient.pending.type]: (state) => {
 			state.loadingClients = true;
+			state.errorLoadingClients = null;
 		},
 		[deleteOAuthClient.rejected.type]: (state, action: PayloadAction<IErrorsAxiosResponse>) => {
 			state.loadingClients = false;

--- a/src/store/oauthClients/types.ts
+++ b/src/store/oauthClients/types.ts
@@ -1,18 +1,19 @@
 import { IErrorsAxiosResponse } from '@uspacy/sdk/lib/models/errors';
 
 // TODO: import from @uspacy/sdk once published with oauthClients
+// NOTE: client fields are SNAKE_CASE (raw shape from auth-service via users-backend).
 export interface IOAuthClient {
-	clientId: string;
+	client_id: string;
 	name: string;
-	grantTypes: string[];
-	redirectUris: string[] | null;
+	grant_types: string[];
+	redirect_uris: string[] | null;
 	confidential: boolean;
-	userId: number | null;
+	user_id: number | null;
 	domain: string | null;
 	permissions: string[] | null;
 	revoked: boolean;
-	createdAt: string | number;
-	updatedAt: string | number;
+	created_at: string | number;
+	updated_at: string | number;
 }
 
 export interface IOAuthClientWithSecret extends IOAuthClient {
@@ -36,9 +37,9 @@ export interface IOAuthPermissionGroup {
 export interface IOAuthClientsResponse {
 	data: IOAuthClient[];
 	meta?: {
-		currentPage?: number;
-		lastPage?: number;
-		perPage?: number;
+		current_page?: number;
+		last_page?: number;
+		per_page?: number;
 		total?: number;
 		from?: number;
 		to?: number;

--- a/src/store/oauthClients/types.ts
+++ b/src/store/oauthClients/types.ts
@@ -58,5 +58,6 @@ export interface IState {
 	loadingClients: boolean;
 	loadingPermissions: boolean;
 	creating: boolean;
+	updating: boolean;
 	errorLoadingClients: IErrorsAxiosResponse;
 }

--- a/src/store/oauthClients/types.ts
+++ b/src/store/oauthClients/types.ts
@@ -1,0 +1,61 @@
+import { IErrorsAxiosResponse } from '@uspacy/sdk/lib/models/errors';
+
+// TODO: import from @uspacy/sdk once published with oauthClients
+export interface IOAuthClient {
+	clientId: string;
+	name: string;
+	grantTypes: string[];
+	redirectUris: string[] | null;
+	confidential: boolean;
+	userId: number | null;
+	domain: string | null;
+	permissions: string[] | null;
+	revoked: boolean;
+	createdAt: string | number;
+	updatedAt: string | number;
+}
+
+export interface IOAuthClientWithSecret extends IOAuthClient {
+	secret: string;
+}
+
+export interface IOAuthPermissionGroup {
+	key: string;
+	title: string;
+	entity: string;
+	section: string;
+	actions: string[];
+	permissionKeys: {
+		create: string;
+		view: string;
+		edit: string;
+		delete: string;
+	};
+}
+
+export interface IOAuthClientsResponse {
+	data: IOAuthClient[];
+	meta?: {
+		currentPage?: number;
+		lastPage?: number;
+		perPage?: number;
+		total?: number;
+		from?: number;
+		to?: number;
+	};
+}
+
+export interface IOAuthClientRequest {
+	name: string;
+	permissions: string[];
+}
+
+export interface IState {
+	clients: IOAuthClient[];
+	createdClient: IOAuthClientWithSecret | null;
+	availablePermissions: IOAuthPermissionGroup[];
+	loadingClients: boolean;
+	loadingPermissions: boolean;
+	creating: boolean;
+	errorLoadingClients: IErrorsAxiosResponse;
+}

--- a/src/store/oauthClients/types.ts
+++ b/src/store/oauthClients/types.ts
@@ -59,5 +59,5 @@ export interface IState {
 	loadingPermissions: boolean;
 	creating: boolean;
 	updating: boolean;
-	errorLoadingClients: IErrorsAxiosResponse;
+	errorLoadingClients: IErrorsAxiosResponse | null;
 }


### PR DESCRIPTION
## What

Add an `oauthClients` Redux slice for the profile-frontend **External connectors** tab, mirroring the `webhooks` slice. Backs the OAuth-clients list/create/delete + the permission catalog via `@uspacy/sdk` `oauthClientsService`.

> Part of a multi-repo OAuth-clients feature: auth-service → users-backend → uspacy-js-sdk → **this slice** → profile-frontend tab.

## Changes

- `src/store/oauthClients/{types,actions,index}.ts`:
  - thunks: `fetchOAuthClients`, `createOAuthClient`, `deleteOAuthClient`, `fetchAvailablePermissions` — unwrap the users-backend `{ status, data }` envelope (the list reads the paginator's inner `data` array).
  - `createOAuthClient.fulfilled` stores `createdClient` (with the one-time `secret`) and prepends a **secret-stripped** client to the list; `deleteOAuthClient` filters by `clientId`; `clearCreatedClient` reducer.
  - state: `clients`, `createdClient`, `availablePermissions`, `loadingClients`, `loadingPermissions`, `creating`.
- Registered in the root `combineReducers` (key: `oauthClients`).

## Note (interim)

The installed `@uspacy/sdk` does not yet expose `oauthClientsService` (its PR is in review). So the slice defines the interfaces **locally** and casts the SDK (`uspacySdk as any`), both clearly `TODO`-marked. Once `@uspacy/sdk` is published with `oauthClientsService`, swap the local interfaces for `@uspacy/sdk/lib/models/oauthClients` imports and drop the cast.

`tsc --noEmit` + eslint clean.
