### PR TITLE
feat(messengerExternal): per-status cursor pagination + page state

### DIFF
--- a/src/store/messenger/messengerExternal/actions.ts
+++ b/src/store/messenger/messengerExternal/actions.ts
@@ -1,9 +1,46 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { uspacySdk } from '@uspacy/sdk';
-import { IChat } from '@uspacy/sdk/lib/models/messenger';
+import { IChat, IExternalChatStatus } from '@uspacy/sdk/lib/models/messenger';
 import { IUser } from '@uspacy/sdk/lib/models/user';
 
 import { formatChats } from '../../../helpers/messenger';
+
+const DEFAULT_EXTERNAL_PAGE_SIZE = 30;
+
+/**
+ * Cursor (keyset) paginated fetch of ONE external status bucket.
+ * Omit `cursor` for the first page (which also returns the `pinned` block).
+ */
+export const fetchExternalChatsPage = createAsyncThunk(
+	'messenger/fetchExternalChatsPage',
+	async (
+		{
+			status,
+			cursor,
+			limit = DEFAULT_EXTERNAL_PAGE_SIZE,
+			getFormattedUserName,
+		}: { status: IExternalChatStatus; cursor?: string; limit?: number; getFormattedUserName: (u: Partial<IUser>) => string },
+		{ rejectWithValue, getState },
+	) => {
+		try {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const state: any = getState();
+			const users = state.users.data.filter((u) => u.authUserId);
+			const profile = state.profile.data;
+			const { data } = await uspacySdk.messengerService.getExternalChatsPage({ externalStatuses: status, cursor, limit });
+			return {
+				status,
+				isFirstPage: !cursor,
+				pinned: data.pinned ? formatChats(data.pinned, users, profile, getFormattedUserName) : [],
+				data: formatChats(data.data, users, profile, getFormattedUserName),
+				nextCursor: data.nextCursor,
+				hasNext: data.hasNext,
+			};
+		} catch (e) {
+			return rejectWithValue(e);
+		}
+	},
+);
 
 export const fetchExternalChats = createAsyncThunk(
 	'messenger/fetchExternalChats',

--- a/src/store/messenger/messengerExternal/index.ts
+++ b/src/store/messenger/messengerExternal/index.ts
@@ -6,6 +6,7 @@ import { IUser } from '@uspacy/sdk/lib/models/user';
 
 import {
 	checkExtChatStatus,
+	getUniqueItems,
 	onlyUnique,
 	readLastMessageInChat,
 	readLastMessagesInChat,
@@ -16,8 +17,22 @@ import {
 	updateLastMessageInExternalChat,
 	updateUnreadCountAndMentionedByChatId,
 } from '../../../helpers/messenger';
-import { fetchAllExternalChats, fetchExternalChats } from './actions';
-import { IState } from './types';
+import { fetchAllExternalChats, fetchExternalChats, fetchExternalChatsPage } from './actions';
+import { IExternalChatsPagination, IState } from './types';
+
+const STATUS_TO_ENUM: Record<'active' | 'undistributed' | 'inactive', EActiveEntity> = {
+	active: EActiveEntity.ACTIVE_EXTERNAL,
+	undistributed: EActiveEntity.UNDISTRIBUTED_EXTERNAL,
+	inactive: EActiveEntity.INACTIVE_EXTERNAL,
+};
+
+const initialPaginationBucket = { cursor: null, hasNext: false, loadingMore: false };
+
+const initialPagination: IExternalChatsPagination = {
+	active: { ...initialPaginationBucket },
+	undistributed: { ...initialPaginationBucket },
+	inactive: { ...initialPaginationBucket },
+};
 
 const initialConnectEntities = {
 	leads: [],
@@ -34,6 +49,7 @@ const initialState: IState = {
 			undistributed: [],
 			inactive: [],
 		},
+		pagination: initialPagination,
 		journalList: {
 			data: [],
 		},
@@ -246,6 +262,42 @@ export const externalChatSlice = createSlice({
 		},
 	},
 	extraReducers: {
+		[fetchExternalChatsPage.pending.type]: (
+			state,
+			action: PayloadAction<unknown, string, { arg: { status: keyof typeof STATUS_TO_ENUM; cursor?: string } }>,
+		) => {
+			const { status, cursor } = action.meta.arg;
+			if (cursor) {
+				state.externalChats.pagination[status].loadingMore = true;
+			} else {
+				state.externalChats.loading = true;
+			}
+		},
+		[fetchExternalChatsPage.fulfilled.type]: (
+			state,
+			action: PayloadAction<{
+				status: keyof typeof STATUS_TO_ENUM;
+				isFirstPage: boolean;
+				pinned: IChat[];
+				data: IChat[];
+				nextCursor: string | null;
+				hasNext: boolean;
+			}>,
+		) => {
+			const { status, isFirstPage, pinned, data, nextCursor, hasNext } = action.payload;
+			const enumStatus = STATUS_TO_ENUM[status];
+			const tagged = [...(isFirstPage ? pinned : []), ...data].map((chat) => ({ ...chat, externalChatStatus: enumStatus }));
+			const existing = isFirstPage ? [] : state.externalChats.items[status];
+			state.externalChats.items[status] = getUniqueItems([...existing, ...tagged]).sort(sortChats);
+			state.externalChats.pagination[status] = { cursor: nextCursor, hasNext, loadingMore: false };
+			state.externalChats.loading = false;
+			state.externalChats.externalChatsLength =
+				state.externalChats.items.active.length + state.externalChats.items.undistributed.length + state.externalChats.items.inactive.length;
+		},
+		[fetchExternalChatsPage.rejected.type]: (state, action: PayloadAction<unknown, string, { arg: { status: keyof typeof STATUS_TO_ENUM } }>) => {
+			state.externalChats.pagination[action.meta.arg.status].loadingMore = false;
+			state.externalChats.loading = false;
+		},
 		[fetchExternalChats.fulfilled.type]: (state, action: PayloadAction<IChat[]>) => {
 			state.externalChats.loading = false;
 			state.externalChats.externalChatsLength = action.payload.length;

--- a/src/store/messenger/messengerExternal/types.ts
+++ b/src/store/messenger/messengerExternal/types.ts
@@ -1,9 +1,18 @@
-import { IChat, ICrmConnectEntity, IExternalChatsItems } from '@uspacy/sdk/lib/models/messenger';
+import { IChat, ICrmConnectEntity, IExternalChatsItems, IExternalChatStatus } from '@uspacy/sdk/lib/models/messenger';
 import { IMeta, ITask } from '@uspacy/sdk/lib/models/tasks';
+
+export interface IExternalPaginationBucket {
+	cursor: string | null;
+	hasNext: boolean;
+	loadingMore: boolean;
+}
+
+export type IExternalChatsPagination = Record<IExternalChatStatus, IExternalPaginationBucket>;
 
 export interface IState {
 	externalChats: {
 		items: IExternalChatsItems;
+		pagination: IExternalChatsPagination;
 		journalList: { data: IChat[]; meta?: IMeta };
 		externalChatsLength: number;
 		loading: boolean;


### PR DESCRIPTION
## What & why

Adds **per-status cursor (keyset) pagination** to the external-chats slice, so `chat-frontend` can paginate each bucket (active / undistributed / inactive) instead of loading all external chats in one request. Backend: messenger-backend #330. SDK: uspacy-js-sdk #255.

## Changes (additive — legacy thunks untouched)

**`actions.ts`** — new `fetchExternalChatsPage({ status, cursor, limit=30, getFormattedUserName })` thunk:
- Calls `uspacySdk.messengerService.getExternalChatsPage({ externalStatuses: status, cursor, limit })`.
- First page (no cursor) also returns the `pinned` block; formats chats via existing `formatChats`.
- Returns `{ status, isFirstPage, pinned, data, nextCursor, hasNext }`.

**`types.ts`** — per-bucket page state:
```ts
pagination: Record<IExternalChatStatus, { cursor: string | null; hasNext: boolean; loadingMore: boolean }>
```

**`index.ts`** — `initialPagination`, `STATUS_TO_ENUM`, and `fetchExternalChatsPage` extraReducers:
- **pending**: `loadingMore` for cursor pages, global `loading` for first page.
- **fulfilled**: first page replaces the bucket; cursor page appends + dedupes (`getUniqueItems`) + re-sorts (`sortChats`, pinned-first); tags `externalChatStatus`; recomputes `externalChatsLength`.
- **rejected**: clears the bucket's `loadingMore`.

`fetchExternalChats` / `fetchAllExternalChats` and all existing reducers (`addChatToActiveIfDontExists`, etc.) are unchanged.

## Verify

- `tsc --noEmit`: **no errors in `messengerExternal/`** (other pre-existing type errors come from the installed SDK being older than source — unrelated).
- `eslint` on changed files: clean.
- No test suite in this repo.

## Dependency / ordering

Requires the SDK method `getExternalChatsPage` — **merge & publish uspacy-js-sdk #255 first**, then bump `@uspacy/sdk` here. Verified locally against a dev-linked SDK build.