### PR TITLE
feat(messengerExternal): per-status cursor pagination + page state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uspacy/store",
-  "version": "0.0.331",
+  "version": "0.0.332",
   "keywords": [],
   "repository": "git@github.com:Uspacy/uspacy-store.git",
   "license": "ISC",
@@ -27,7 +27,7 @@
     "@typescript-eslint/eslint-plugin": "6.3.0",
     "@typescript-eslint/parser": "6.3.0",
     "@uspacy/forms": "1.0.8",
-    "@uspacy/sdk": "0.0.242",
+    "@uspacy/sdk": "0.0.243",
     "cross-env": "7.0.3",
     "date-fns": "2.30.0",
     "dotenv-webpack": "8.0.1",

--- a/src/store/messenger/messengerExternal/actions.ts
+++ b/src/store/messenger/messengerExternal/actions.ts
@@ -25,14 +25,14 @@ export const fetchExternalChatsPage = createAsyncThunk(
 		try {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			const state: any = getState();
-			const users = state.users.data.filter((u) => u.authUserId);
-			const profile = state.profile.data;
+			const users = (state.users?.data || []).filter((u) => u.authUserId);
+			const profile = state.profile?.data || {};
 			const { data } = await uspacySdk.messengerService.getExternalChatsPage({ externalStatuses: status, cursor, limit });
 			return {
 				status,
 				isFirstPage: !cursor,
 				pinned: data.pinned ? formatChats(data.pinned, users, profile, getFormattedUserName) : [],
-				data: formatChats(data.data, users, profile, getFormattedUserName),
+				data: formatChats(data.data || [], users, profile, getFormattedUserName),
 				nextCursor: data.nextCursor,
 				hasNext: data.hasNext,
 			};

--- a/src/store/messenger/messengerExternal/actions.ts
+++ b/src/store/messenger/messengerExternal/actions.ts
@@ -1,8 +1,46 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { uspacySdk } from '@uspacy/sdk';
+import { IExternalChatStatus } from '@uspacy/sdk/lib/models/messenger';
 import { IUser } from '@uspacy/sdk/lib/models/user';
 
 import { formatChats } from '../../../helpers/messenger';
+
+const DEFAULT_EXTERNAL_PAGE_SIZE = 30;
+
+/**
+ * Cursor (keyset) paginated fetch of ONE external status bucket.
+ * Omit `cursor` for the first page (which also returns the `pinned` block).
+ */
+export const fetchExternalChatsPage = createAsyncThunk(
+	'messenger/fetchExternalChatsPage',
+	async (
+		{
+			status,
+			cursor,
+			limit = DEFAULT_EXTERNAL_PAGE_SIZE,
+			getFormattedUserName,
+		}: { status: IExternalChatStatus; cursor?: string; limit?: number; getFormattedUserName: (u: Partial<IUser>) => string },
+		{ rejectWithValue, getState },
+	) => {
+		try {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const state: any = getState();
+			const users = state.users.data.filter((u) => u.authUserId);
+			const profile = state.profile.data;
+			const { data } = await uspacySdk.messengerService.getExternalChatsPage({ externalStatuses: status, cursor, limit });
+			return {
+				status,
+				isFirstPage: !cursor,
+				pinned: data.pinned ? formatChats(data.pinned, users, profile, getFormattedUserName) : [],
+				data: formatChats(data.data, users, profile, getFormattedUserName),
+				nextCursor: data.nextCursor,
+				hasNext: data.hasNext,
+			};
+		} catch (e) {
+			return rejectWithValue(e);
+		}
+	},
+);
 
 export const fetchExternalChats = createAsyncThunk(
 	'messenger/fetchExternalChats',

--- a/src/store/messenger/messengerExternal/index.ts
+++ b/src/store/messenger/messengerExternal/index.ts
@@ -241,6 +241,10 @@ export const externalChatSlice = createSlice({
 			action: PayloadAction<unknown, string, { arg: { status: keyof typeof STATUS_TO_ENUM; cursor?: string } }>,
 		) => {
 			const { status, cursor } = action.meta.arg;
+			// pagination can be missing when state is hydrated from an older persisted shape
+			if (!state.externalChats.pagination) {
+				state.externalChats.pagination = { ...initialPagination };
+			}
 			if (cursor) {
 				state.externalChats.pagination[status].loadingMore = true;
 			} else {
@@ -261,15 +265,23 @@ export const externalChatSlice = createSlice({
 			const { status, isFirstPage, pinned, data, nextCursor, hasNext } = action.payload;
 			const enumStatus = STATUS_TO_ENUM[status];
 			const tagged = [...(isFirstPage ? pinned : []), ...data].map((chat) => ({ ...chat, externalChatStatus: enumStatus }));
-			const existing = isFirstPage ? [] : state.externalChats.items[status];
+			const existing = isFirstPage ? [] : state.externalChats.items[status] || [];
 			state.externalChats.items[status] = getUniqueItems([...existing, ...tagged]).sort(sortChats);
+			if (!state.externalChats.pagination) {
+				state.externalChats.pagination = { ...initialPagination };
+			}
 			state.externalChats.pagination[status] = { cursor: nextCursor, hasNext, loadingMore: false };
 			state.externalChats.loading = false;
 			state.externalChats.externalChatsLength =
-				state.externalChats.items.active.length + state.externalChats.items.undistributed.length + state.externalChats.items.inactive.length;
+				(state.externalChats.items.active?.length || 0) +
+				(state.externalChats.items.undistributed?.length || 0) +
+				(state.externalChats.items.inactive?.length || 0);
 		},
 		[fetchExternalChatsPage.rejected.type]: (state, action: PayloadAction<unknown, string, { arg: { status: keyof typeof STATUS_TO_ENUM } }>) => {
-			state.externalChats.pagination[action.meta.arg.status].loadingMore = false;
+			const status = action.meta?.arg?.status;
+			if (status && state.externalChats.pagination?.[status]) {
+				state.externalChats.pagination[status].loadingMore = false;
+			}
 			state.externalChats.loading = false;
 		},
 		[fetchExternalChats.fulfilled.type]: (state, action: PayloadAction<IChat[]>) => {

--- a/src/store/messenger/messengerExternal/index.ts
+++ b/src/store/messenger/messengerExternal/index.ts
@@ -1,9 +1,10 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { IChat, ICrmConnectEntity, IMessage } from '@uspacy/sdk/lib/models/messenger';
+import { EActiveEntity, IChat, ICrmConnectEntity, IMessage } from '@uspacy/sdk/lib/models/messenger';
 import { ITask } from '@uspacy/sdk/lib/models/tasks';
 import { IUser } from '@uspacy/sdk/lib/models/user';
 
 import {
+	getUniqueItems,
 	onlyUnique,
 	readLastMessageInChat,
 	readLastMessagesInChat,
@@ -13,8 +14,22 @@ import {
 	updateLastMessageInExternalChat,
 	updateUnreadCountAndMentionedByChatId,
 } from '../../../helpers/messenger';
-import { fetchExternalChats } from './actions';
-import { IState } from './types';
+import { fetchExternalChats, fetchExternalChatsPage } from './actions';
+import { IExternalChatsPagination, IState } from './types';
+
+const STATUS_TO_ENUM: Record<'active' | 'undistributed' | 'inactive', EActiveEntity> = {
+	active: EActiveEntity.ACTIVE_EXTERNAL,
+	undistributed: EActiveEntity.UNDISTRIBUTED_EXTERNAL,
+	inactive: EActiveEntity.INACTIVE_EXTERNAL,
+};
+
+const initialPaginationBucket = { cursor: null, hasNext: false, loadingMore: false };
+
+const initialPagination: IExternalChatsPagination = {
+	active: { ...initialPaginationBucket },
+	undistributed: { ...initialPaginationBucket },
+	inactive: { ...initialPaginationBucket },
+};
 
 const initialConnectEntities = {
 	leads: [],
@@ -31,6 +46,7 @@ const initialState: IState = {
 			undistributed: [],
 			inactive: [],
 		},
+		pagination: initialPagination,
 		externalChatsLength: 0,
 		crmConnectEntities: initialConnectEntities,
 		connectedTasks: [],
@@ -220,6 +236,42 @@ export const externalChatSlice = createSlice({
 		},
 	},
 	extraReducers: {
+		[fetchExternalChatsPage.pending.type]: (
+			state,
+			action: PayloadAction<unknown, string, { arg: { status: keyof typeof STATUS_TO_ENUM; cursor?: string } }>,
+		) => {
+			const { status, cursor } = action.meta.arg;
+			if (cursor) {
+				state.externalChats.pagination[status].loadingMore = true;
+			} else {
+				state.externalChats.loading = true;
+			}
+		},
+		[fetchExternalChatsPage.fulfilled.type]: (
+			state,
+			action: PayloadAction<{
+				status: keyof typeof STATUS_TO_ENUM;
+				isFirstPage: boolean;
+				pinned: IChat[];
+				data: IChat[];
+				nextCursor: string | null;
+				hasNext: boolean;
+			}>,
+		) => {
+			const { status, isFirstPage, pinned, data, nextCursor, hasNext } = action.payload;
+			const enumStatus = STATUS_TO_ENUM[status];
+			const tagged = [...(isFirstPage ? pinned : []), ...data].map((chat) => ({ ...chat, externalChatStatus: enumStatus }));
+			const existing = isFirstPage ? [] : state.externalChats.items[status];
+			state.externalChats.items[status] = getUniqueItems([...existing, ...tagged]).sort(sortChats);
+			state.externalChats.pagination[status] = { cursor: nextCursor, hasNext, loadingMore: false };
+			state.externalChats.loading = false;
+			state.externalChats.externalChatsLength =
+				state.externalChats.items.active.length + state.externalChats.items.undistributed.length + state.externalChats.items.inactive.length;
+		},
+		[fetchExternalChatsPage.rejected.type]: (state, action: PayloadAction<unknown, string, { arg: { status: keyof typeof STATUS_TO_ENUM } }>) => {
+			state.externalChats.pagination[action.meta.arg.status].loadingMore = false;
+			state.externalChats.loading = false;
+		},
 		[fetchExternalChats.fulfilled.type]: (state, action: PayloadAction<IChat[]>) => {
 			state.externalChats.loading = false;
 			state.externalChats.externalChatsLength = action.payload.length;

--- a/src/store/messenger/messengerExternal/types.ts
+++ b/src/store/messenger/messengerExternal/types.ts
@@ -1,9 +1,18 @@
-import { ICrmConnectEntity, IExternalChatsItems } from '@uspacy/sdk/lib/models/messenger';
+import { ICrmConnectEntity, IExternalChatsItems, IExternalChatStatus } from '@uspacy/sdk/lib/models/messenger';
 import { ITask } from '@uspacy/sdk/lib/models/tasks';
+
+export interface IExternalPaginationBucket {
+	cursor: string | null;
+	hasNext: boolean;
+	loadingMore: boolean;
+}
+
+export type IExternalChatsPagination = Record<IExternalChatStatus, IExternalPaginationBucket>;
 
 export interface IState {
 	externalChats: {
 		items: IExternalChatsItems;
+		pagination: IExternalChatsPagination;
 		externalChatsLength: number;
 		loading: boolean;
 		currentChatId?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2502,10 +2502,10 @@
     lint-staged "15.2.10"
     localforage "1.10.0"
 
-"@uspacy/sdk@0.0.242":
-  version "0.0.242"
-  resolved "https://npm.pkg.github.com/download/@uspacy/sdk/0.0.242/3e3c5b8950b77e805e9be9363717914a50ffe075#3e3c5b8950b77e805e9be9363717914a50ffe075"
-  integrity sha512-PsAUHDZalbsRwsNZcILRJR/Vr6hp72LCOaL6hhK0j8UraLpgMxFdFzDnMvxApAnhpPyPIqH5tJgDHY5j9tJqIA==
+"@uspacy/sdk@0.0.243":
+  version "0.0.243"
+  resolved "https://npm.pkg.github.com/download/@uspacy/sdk/0.0.243/063d030af2555d79c9d06f953e80fc0d9dce4f9c#063d030af2555d79c9d06f953e80fc0d9dce4f9c"
+  integrity sha512-qyrfZZwjXsOqKph+9tMCcRRi54TPXmKtkTjHT7lmf0HAJJtZh+tciN0BHQFXGzy4rx1eeTss533QH+7h+6Yvcw==
   dependencies:
     axios "^1.9.0"
     js-cookie "3.0.5"
@@ -8065,7 +8065,16 @@ string-argv@^0.3.1, string-argv@~0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8134,7 +8143,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -8952,7 +8968,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -8965,6 +8981,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## What & why

Brings the external-chats **per-status cursor pagination** store layer into `main` (it currently lives only on `stage`; the earlier PR #352 was merged into stage). Consumed by `chat-frontend`; depends on `@uspacy/sdk` `getExternalChatsPage` (uspacy-js-sdk #260); backend: messenger-backend #330.

This is a **cursor-only isolation** of the stage change — it adds just the pagination thunk/state on top of `main`, without the other stage-only messenger features (journal-chats, tasks-with-ext-lines, socket updates), which promote separately.

## Changes (additive — legacy thunk untouched)

**`actions.ts`** — new `fetchExternalChatsPage({ status, cursor, limit=30, getFormattedUserName })`:
- Calls `uspacySdk.messengerService.getExternalChatsPage({ externalStatuses: status, cursor, limit })`.
- First page (no cursor) also returns the `pinned` block; formats via existing `formatChats`.
- Returns `{ status, isFirstPage, pinned, data, nextCursor, hasNext }`.

**`types.ts`** — per-bucket page state:
```ts
pagination: Record<IExternalChatStatus, { cursor: string | null; hasNext: boolean; loadingMore: boolean }>
```

**`index.ts`** — `initialPagination`, `STATUS_TO_ENUM`, and `fetchExternalChatsPage` extraReducers (pending/fulfilled/rejected): first page replaces the bucket; cursor page appends + dedupes (`getUniqueItems`) + re-sorts (`sortChats`, pinned-first); tags `externalChatStatus`; recomputes `externalChatsLength`.

`fetchExternalChats` and existing reducers are unchanged.

## Verify

- `tsc --noEmit`: no errors in `messengerExternal/` (typechecked against the installed `@uspacy/sdk` which already exposes `getExternalChatsPage`).
- `eslint` on changed files: clean.

## Dependency / ordering

Requires `@uspacy/sdk` `getExternalChatsPage` — land uspacy-js-sdk #260 (and bump `@uspacy/sdk` here) alongside this. Same change already merged to `stage` (PR #352).